### PR TITLE
[codex] Make protected screenshots config-driven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 
 # Local Netlify folder
 .netlify
+
+scripts/AutoUpdate/ignore/

--- a/scripts/AutoUpdate/auto_update.py
+++ b/scripts/AutoUpdate/auto_update.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import tomllib
 
-from utilities import get_screenshots_used_in_markdown_file, rewrite_screenshot_embeds
+from utilities import SCREENSHOT_PREFIX, get_screenshots_used_in_markdown_file, rewrite_screenshot_embeds
 
 logger = logging.getLogger(__name__)
 log_format = "%(asctime)-15s - %(levelname)s - %(message)s"
@@ -23,16 +23,13 @@ logger.debug(f"Loaded config: {config}")
 #
 # 1. Check for unused screenshots. If any are found, throw warnings/errors.
 #
-# corrode_wall_screenshots = get_screenshots_used_in_markdown_file(
-#     "E:/Obsidian/Vaults/My Vault/Gaming/Valorant Sage Walls/Corrode.md")
-# killjoy_screenshots = get_screenshots_used_in_markdown_file("E:/Obsidian/Vaults/My Vault/Gaming/Valorant KillJoy.md")
-protected_screenshots = {
-    "Breeze": get_screenshots_used_in_markdown_file(
-        "E:/Obsidian/Vaults/My Vault/Gaming/Valorant Sage Walls/Breeze.md"),
-    "Corrode": get_screenshots_used_in_markdown_file(
-        "E:/Obsidian/Vaults/My Vault/Gaming/Valorant Sage Walls/Corrode.md"),
-    "KillJoy": get_screenshots_used_in_markdown_file("E:/Obsidian/Vaults/My Vault/Gaming/Valorant KillJoy.md")
-}
+protected_screenshots = {}
+for protected_markdown_file in config.get('protected_markdown_files', []):
+    if os.path.isfile(protected_markdown_file):
+        map_name = os.path.splitext(os.path.basename(protected_markdown_file))[0]
+        protected_screenshots[map_name] = get_screenshots_used_in_markdown_file(protected_markdown_file)
+    else:
+        logger.warning(f"Configured protected markdown file does not exist, skipping: {protected_markdown_file}")
 
 
 def check_unused_files(screenshots_dir: str, md_dir: str) -> set[str]:
@@ -79,20 +76,21 @@ unused_screenshots = check_unused_files(config['obsidian_screenshots_directory']
 
 # TODO: move/organize screenshots into directories based on the map name
 if config['copy_screenshots']:
+    protected_stripped = {
+        screenshot.removeprefix(SCREENSHOT_PREFIX)
+        for screenshots in protected_screenshots.values()
+        for screenshot in screenshots
+    }
+
     # remove all screenshots from target directory, in case some screenshots are no longer used
     for filename in os.listdir(config['git_screenshots_directory']):
         file_path = os.path.join(config['git_screenshots_directory'], filename)
         if os.path.isfile(file_path) and filename.endswith('.png'):
 
             # protect these screenshots for now
-            is_protected = False
-            for map_name, screenshots in protected_screenshots.items():
-                if filename in screenshots:
-                    logger.debug(f"Protecting {map_name} screenshot from deletion: {filename}")
-                    is_protected = True
-                    break
-
-            if not is_protected:
+            if filename in protected_stripped:
+                logger.debug(f"Protecting screenshot from deletion: {filename}")
+            else:
                 # print("Removing file: {}".format(file_path))
                 os.remove(file_path)
 
@@ -107,7 +105,7 @@ if config['copy_screenshots']:
             logger.warning("Skipping unused screenshot: {}".format(screenshot))
             continue
 
-        screenshot = screenshot[13:]
+        screenshot = screenshot.removeprefix(SCREENSHOT_PREFIX)
         if screenshot not in screenshots_in_repo:
             src_file = os.path.join(config['obsidian_screenshots_directory'], original_screenshot)
             dst_file = os.path.join(config['git_screenshots_directory'], screenshot)

--- a/scripts/AutoUpdate/example_app.conf
+++ b/scripts/AutoUpdate/example_app.conf
@@ -20,3 +20,11 @@ enable_markdown_auto_format = true
 
 # Should we copy screenshots from Obsidian to Git Repository ?
 copy_screenshots = false
+
+# Optional Markdown files whose referenced screenshots should be protected from
+# unused warnings and copy_screenshots deletion.
+protected_markdown_files = [
+    'E:/Obsidian/Vaults/My Vault/Gaming/Valorant Sage Walls/Breeze.md',
+    'E:/Obsidian/Vaults/My Vault/Gaming/Valorant Sage Walls/Corrode.md',
+    'E:/Obsidian/Vaults/My Vault/Gaming/Valorant KillJoy.md',
+]


### PR DESCRIPTION
## Summary

- Replaces the hardcoded protected screenshot markdown paths with optional `protected_markdown_files` config.
- Warns and skips missing protected markdown files instead of crashing at import time.
- Fixes deletion-time protection by comparing repo screenshot filenames against prefix-stripped protected names.
- Replaces the remaining `screenshot[13:]` magic slice with `removeprefix(SCREENSHOT_PREFIX)`.
- Documents the new config key in `scripts/AutoUpdate/example_app.conf`.

## Why

Protected screenshots were loaded from hardcoded absolute paths at import time, so missing or renamed files crashed the script before sync work could begin. The deletion guard also compared stripped repo filenames against names that still included `Pasted image `, so protected screenshots were not actually protected during deletion.

## Migration Note

`app.conf` is untracked and local. Before running this change, add the desired protected markdown files to local `app.conf`, for example:

```toml
protected_markdown_files = [
    'E:/Obsidian/Vaults/My Vault/Gaming/Valorant Sage Walls/Breeze.md',
    'E:/Obsidian/Vaults/My Vault/Gaming/Valorant Sage Walls/Corrode.md',
    'E:/Obsidian/Vaults/My Vault/Gaming/Valorant KillJoy.md',
]
```

If this key is absent, it defaults to an empty list. On a future `copy_screenshots = true` run, those screenshots may be flagged unused or deleted unless local `app.conf` is updated.

## Validation

- `uv --cache-dir .\.uv-cache run mypy auto_update.py utilities.py`
- `uv --cache-dir .\.uv-cache run python -m py_compile auto_update.py utilities.py`
- Temp-directory behavior exercise proving a protected repo-side stripped PNG is preserved rather than deleted and re-copied, and a missing protected markdown path warns instead of raising.
- `git diff --check -- auto_update.py example_app.conf`
- `git ls-files --eol -- auto_update.py example_app.conf` shows `i/lf w/lf` for both touched files.
